### PR TITLE
Disable loop check default

### DIFF
--- a/php_yasd.h
+++ b/php_yasd.h
@@ -31,7 +31,7 @@ ZEND_BEGIN_MODULE_GLOBALS(yasd)
     uint16_t remote_port;
     uint16_t depth;
     int log_level;
-    int max_executed_opline_num;
+    ssize_t max_executed_opline_num;
 
     // compatible with phpstorm
     int coverage_enable;

--- a/tests/extension_ini/yasd.ini
+++ b/tests/extension_ini/yasd.ini
@@ -2,4 +2,5 @@ zend_extension=yasd
 yasd.debug_mode=remote
 yasd.remote_host=127.0.0.1
 yasd.remote_port=9000
+yasd.max_executed_opline_num=50000
 yasd.depth=1

--- a/yasd.cc
+++ b/yasd.cc
@@ -53,7 +53,7 @@ STD_PHP_INI_ENTRY("yasd.depth", "1", PHP_INI_ALL, OnUpdateLong,
         depth, zend_yasd_globals, yasd_globals)
 STD_PHP_INI_ENTRY("yasd.log_level", "-1", PHP_INI_ALL, OnUpdateLong,
         log_level, zend_yasd_globals, yasd_globals)
-STD_PHP_INI_ENTRY("yasd.max_executed_opline_num", "10000", PHP_INI_ALL, OnUpdateLong,
+STD_PHP_INI_ENTRY("yasd.max_executed_opline_num", "0", PHP_INI_ALL, OnUpdateLong,
         max_executed_opline_num, zend_yasd_globals, yasd_globals)
 
 // compatible with phpstorm
@@ -196,12 +196,12 @@ bool is_infinite_loop() {
 
     yasd::CurrentFunctionStatus *function_status = context->function_status.back();
 
-    if (function_status->executed_opline_num < YASD_G(max_executed_opline_num)) {
-        return false;
+    if (YASD_G(max_executed_opline_num) > 0 && function_status->executed_opline_num >= YASD_G(max_executed_opline_num)) {
+        function_status->executed_opline_num = 0;
+        return true;
     }
 
-    function_status->executed_opline_num = 0;
-    return true;
+    return false;
 }
 
 ZEND_DLEXPORT void yasd_statement_call(zend_execute_data *frame) {


### PR DESCRIPTION
Some frameworks will read all files in a project, such as frameworks that support annotations, which will read every token in every file, which will lead to a lot of loops.