### PR TITLE
Fix php version 8.1 build. 

### DIFF
--- a/src/base.cc
+++ b/src/base.cc
@@ -45,9 +45,7 @@ void execute_init_file() {
         exit(255);
     }
 
-    memset(&file_handle, 0, sizeof(zend_file_handle));
-    file_handle.type = ZEND_HANDLE_FILENAME;
-    file_handle.filename = YASD_G(init_file);
+    zend_stream_init_filename(&file_handle, YASD_G(init_file));
 
     CG(compiler_options) &= ~ZEND_COMPILE_EXTENDED_INFO;
     op_array = zend_compile_file(&file_handle, ZEND_EVAL);


### PR DESCRIPTION
Don't access zend_file_handle internals directly, use abstraction: zend_stream_init_filename to properly initialize it.