### PR TITLE
Fix building warnings

### DIFF
--- a/.github/workflows/ext.yml
+++ b/.github/workflows/ext.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-16.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         php: [7.2, 7.3, 7.4, 8.0]
     steps:
     - uses: actions/checkout@v1

--- a/php_yasd.h
+++ b/php_yasd.h
@@ -26,7 +26,7 @@
 extern zend_module_entry yasd_module_entry;
 #define phpext_yasd_ptr &yasd_module_entry
 
-#define PHP_YASD_VERSION "0.3.9-alpha"
+#define PHP_YASD_VERSION (char*)"0.3.9-alpha"
 
 ZEND_BEGIN_MODULE_GLOBALS(yasd)
     char *breakpoints_file;

--- a/src/cmder_debugger.cc
+++ b/src/cmder_debugger.cc
@@ -378,7 +378,6 @@ int CmderDebugger::parse_watch_cmd() {
 }
 
 int CmderDebugger::parse_unwatch_cmd() {
-    zend_function *func = EG(current_execute_data)->func;
     std::vector<std::string> exploded_cmd;
 
     boost::split(exploded_cmd, last_cmd, boost::is_any_of(" "), boost::token_compress_on);

--- a/src/cmder_debugger.cc
+++ b/src/cmder_debugger.cc
@@ -33,7 +33,7 @@ namespace yasd {
 CmderDebugger::CmderDebugger() {}
 
 void CmderDebugger::init() {
-    int status;
+    int status = -1;
     std::string cmd;
 
     show_welcome_info();
@@ -52,7 +52,7 @@ void CmderDebugger::init() {
 }
 
 void CmderDebugger::handle_request(const char *filename, int lineno) {
-    int status;
+    int status = -1;
     std::string cmd;
     yasd::SourceReader reader(filename);
     std::vector<std::string> exploded_cmd;

--- a/src/dbgp.cc
+++ b/src/dbgp.cc
@@ -229,7 +229,6 @@ void Dbgp::get_zend_object_child_property_doc(tinyxml2::XMLElement *child, const
     zend_string *class_name;
     zend_array *properties;
     class_name = Z_OBJCE_P(property_element.value)->name;
-    zend_ulong num;
     zend_string *key;
     zval *val;
 

--- a/src/dbgp.cc
+++ b/src/dbgp.cc
@@ -229,6 +229,7 @@ void Dbgp::get_zend_object_child_property_doc(tinyxml2::XMLElement *child, const
     zend_string *class_name;
     zend_array *properties;
     class_name = Z_OBJCE_P(property_element.value)->name;
+    zend_ulong num;
     zend_string *key;
     zval *val;
 

--- a/src/debuger_mode_base.cc
+++ b/src/debuger_mode_base.cc
@@ -26,7 +26,7 @@ int DebuggerModeBase::parse_step_over_cmd() {
     yasd::Context *context = global->get_current_context();
     zend_execute_data *frame = EG(current_execute_data);
 
-    uint32_t func_line_end = frame->func->op_array.line_end;
+    unsigned int func_line_end = frame->func->op_array.line_end;
 
     if (frame->opline->lineno == func_line_end && context->level != 1) {
         global->do_step = true;

--- a/src/debuger_mode_base.cc
+++ b/src/debuger_mode_base.cc
@@ -26,7 +26,7 @@ int DebuggerModeBase::parse_step_over_cmd() {
     yasd::Context *context = global->get_current_context();
     zend_execute_data *frame = EG(current_execute_data);
 
-    int func_line_end = frame->func->op_array.line_end;
+    uint32_t func_line_end = frame->func->op_array.line_end;
 
     if (frame->opline->lineno == func_line_end && context->level != 1) {
         global->do_step = true;

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -45,33 +45,10 @@ Logger &Logger::set_level(int level) {
 }
 
 void Logger::put(int level, const char *content, size_t length) {
-    const char *level_str;
     int n;
 
     if (level < log_level) {
         return;
-    }
-
-    switch (level) {
-    case DEBUG:
-        level_str = "DEBUG";
-        break;
-    case TRACE:
-        level_str = "TRACE";
-        break;
-    case NOTICE:
-        level_str = "NOTICE";
-        break;
-    case WARNING:
-        level_str = "WARNING";
-        break;
-    case ERROR:
-        level_str = "ERROR";
-        break;
-    case INFO:
-    default:
-        level_str = "INFO";
-        break;
     }
 
     // TODO(codinghuang): seems there are "buffer overflow detected" problem

--- a/yasd.cc
+++ b/yasd.cc
@@ -223,7 +223,6 @@ ZEND_DLEXPORT void yasd_statement_call(zend_execute_data *frame) {
     const zend_op *online = EG(current_execute_data)->opline;
     const char *filename;
     int lineno;
-    int start_lineno;
 
     yasd::Context *context = global->get_current_context();
     
@@ -234,7 +233,6 @@ ZEND_DLEXPORT void yasd_statement_call(zend_execute_data *frame) {
     }
 
     filename = yasd::util::execution::get_filename();
-    start_lineno = lineno = online->lineno;
 
     if (global->debugger->is_hit_watch_point()) {
         return global->debugger->handle_request(filename, lineno);
@@ -337,11 +335,11 @@ zend_extension_version_info extension_version_info = {
 };
 
 zend_extension zend_extension_entry = {
-    "Yasd",
-    PHP_YASD_VERSION,
-    "codinghuang",
-    "https://github.com/huanghantao",
-    "Our Copyright",
+    (char*) "Yasd",
+    (char*) PHP_YASD_VERSION,
+    (char*) "codinghuang",
+    (char*) "https://github.com/huanghantao",
+    (char*) "Our Copyright",
     yasd_zend_startup,
     NULL,
     NULL, /* activate_func_t */

--- a/yasd.cc
+++ b/yasd.cc
@@ -222,7 +222,7 @@ ZEND_DLEXPORT void yasd_statement_call(zend_execute_data *frame) {
     // zend_op_array *op_array = &frame->func->op_array;
     const zend_op *online = EG(current_execute_data)->opline;
     const char *filename;
-    unsigned int lineno = online.lineno;
+    unsigned int lineno = online->lineno;
 
     yasd::Context *context = global->get_current_context();
     

--- a/yasd.cc
+++ b/yasd.cc
@@ -222,7 +222,7 @@ ZEND_DLEXPORT void yasd_statement_call(zend_execute_data *frame) {
     // zend_op_array *op_array = &frame->func->op_array;
     const zend_op *online = EG(current_execute_data)->opline;
     const char *filename;
-    int lineno;
+    unsigned int lineno = online.lineno;
 
     yasd::Context *context = global->get_current_context();
     


### PR DESCRIPTION
While building yasd where are a lot of warnings:
```
/tmp/yasd/yasd.cc:226:9: warning: variable 'start_lineno' set but not used [-Wunused-but-set-variable]
  226 |     int start_lineno;
      |     ^~~~~~~~~~~~~~~~~~~~~~~
/tmp/yasd/yasd.cc:340:5: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  340 |     "Yasd",
      |     ^~~~~~
In file included from /tmp/yasd/yasd.cc:33:
/tmp/yasd/./php_yasd.h:29:26: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
   29 | #define PHP_YASD_VERSION "0.3.9-alpha"
      |                          ^~~~~~~~~~~~~
/tmp/yasd/yasd.cc:341:5: note: in expansion of macro 'PHP_YASD_VERSION'
  341 |     PHP_YASD_VERSION,
      |     ^~~~~~~~~~~~~~~~
/tmp/yasd/yasd.cc:342:5: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  342 |     "codinghuang",
      |     ^~~~~~~~~~~~~
/tmp/yasd/yasd.cc:343:5: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  343 |     "https://github.com/huanghantao",
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/yasd/yasd.cc:344:5: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  344 |     "Our Copyright",
      |     ^~~~~~~~~~~~~~~

```

The PR fixes them